### PR TITLE
preparing browser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ build/Release
 node_modules
 
 
-typings
-lib
+typings/
+lib/
+browser/

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "mocha": "^2.5.3",
     "phantomjs-prebuilt": "^2.1.7",
+    "ts-loader": "^0.8.2",
     "typescript": "^1.8.10",
-    "typings": "^1.0.4"
+    "typings": "^1.0.4",
+    "webpack": "^1.13.1"
   },
   "dependencies": {
     "es6-promise": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "./node_modules/.bin/mocha './test/**/*.spec.js' -r ./test/globals --recursive",
     "build": "npm run build:main && npm run build:browser",
     "build:main": "./node_modules/.bin/tsc -p tsconfig.json",
+    "build:tsd": "./node_modules/.bin/tsc -p tsconfig.json -d",
     "build:browser": "./node_modules/.bin/webpack -p",
     "prepublish": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run build:main && npm run build:browser",
     "build:main": "./node_modules/.bin/tsc -p tsconfig.json",
     "build:browser": "./node_modules/.bin/webpack -p",
-    "prepublish": "npm build"
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "typings": "lib/annict.d.ts",
   "scripts": {
     "test": "./node_modules/.bin/mocha './test/**/*.spec.js' -r ./test/globals --recursive",
-    "build": "./node_modules/.bin/tsc -p tsconfig.json",
-    "prepublish": "./node_modules/.bin/tsc -p tsconfig.json"
+    "build": "npm run build:main && npm run build:browser",
+    "build:main": "./node_modules/.bin/tsc -p tsconfig.json",
+    "build:browser": "./node_modules/.bin/webpack -p",
+    "prepublish": "npm build"
   },
   "repository": {
     "type": "git",

--- a/src/services/authorization-service.ts
+++ b/src/services/authorization-service.ts
@@ -1,6 +1,9 @@
 import { Promise }    from 'es6-promise';
 import { HttpClient } from '../http-client';
 import { Scope }      from '../string-literal';
+import * as qs        from 'qs';
+
+declare const BROWSER : string;
 
 export interface AccessToken {
     access_token : string
@@ -22,8 +25,25 @@ export class AuthorizationService {
     constructor( private client: HttpClient ) {
     }
 
-    authorize() {
-        throw Error('Not Implemented');
+    authorize(
+      client_id     : string,
+      response_type : string   = 'code',
+      redirect_uri  : string   = 'urn:ietf:wg:oauth:2.0:oob',
+      scope         : string[] = ['read'] ) {
+        if(BROWSER) {
+            window.location.assign(
+                'https://api.annict.com/oauth/authorize?'
+                + qs.stringify({
+                    client_id,
+                    response_type,
+                    redirect_uri,
+                    scope: scope.join(' ')
+                })
+            );
+        }
+        else {
+            throw Error('Not Implemented');
+        }
     }
 
     token(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
         "noImplicitAny": false,
         "sourceMap": false,
         "rootDir": "src",
-        "outDir": "lib",
-        "declaration": true
+        "outDir": "lib"
     },
     "filesGlob": [
         "./src/**/*.ts",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,28 @@
+const webpack = require('webpack');
+
+module.exports = {
+    entry: './src/annict.ts',
+    output: {
+        filename: 'annict.min.js',
+        path: './browser',
+    },
+    resolve: {
+        extensions: ['', '.js', '.ts']
+    },
+    module: {
+        loaders: [
+            { test: /\.ts$/, loader: 'ts' }
+        ]
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            VERSION: JSON.stringify(require('./package.json').version),
+            BROWSER: true,
+        }),
+        new webpack.optimize.UglifyJsPlugin({
+            compress: {
+                warnings: false
+            }
+        })
+    ]
+}


### PR DESCRIPTION
#10

webpackでビルドしてannict.min.jsを出力。
こちらでは`annict.OAuth.authorize()`をサポートする

``` js
window.location('https://api.annict.com/oauth/authorize?'+qs.stringify(app));
```
